### PR TITLE
Add Python 3 support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@ A simple Ruby wrapper for processing reStructuredText via Python's Docutils.
 
 ## Installation
 
-Python 2.3+ is required.
+Python 2.3+ (or 3.3+) is required.
 
 RbST is available on [RubyGems.org](http://gemcutter.org/gems/RbST).
 
@@ -56,7 +56,6 @@ For more information on reStructuredText, see the
 
 -   Docutils is very slow. On my 2.5 GHz Core 2 Duo it takes over half a second to convert the test file to HTML, including about 0.2s to start up and 0.38s to process the input data. In other words, this isn't the sort of thing you'd want to be using directly in a Rails view helper.
 -   This has only been tested on \*nix systems.
--   Python 3 has not been tested.
 
 ## Note on Patches/Pull Requests
 

--- a/lib/rst2parts/transform.py
+++ b/lib/rst2parts/transform.py
@@ -23,7 +23,7 @@ def transform(writer=None, part=None):
     
     if len(args) == 1:
         try:
-            content = open(args[0], 'r').read()
+            content = open(args[0], 'rb').read()
         except IOError:
             content = args[0]
     else:
@@ -36,5 +36,5 @@ def transform(writer=None, part=None):
     )
     
     if opts.part in parts:
-        return parts[opts.part].encode(parts["encoding"])
-    return ''
+        return parts[opts.part]
+    return u''


### PR DESCRIPTION
Under Python 3, `sys.stdout.write()` doesn't accept bytes so we need to
give it a unicode string.

`transform()` returned its result encoded in the part's original
encoding, which didn't make much sense so I've removed that part to keep
the result in a unicode string.

I've tested the result with both Python 2 and 3 on a utf8 source file
containing non-ascii characters. Works fine.

Results are a bit fuzzier with source encoding that aren't utf-8, but
that problem was already present before this change.